### PR TITLE
Add financial docs

### DIFF
--- a/bin/mindee.rb
+++ b/bin/mindee.rb
@@ -10,6 +10,10 @@ DOCUMENTS = {
     help: "Custom document type from API builder",
     prediction: Mindee::Prediction::CustomV1,
   },
+  "financial-document" => {
+    help: 'Financial Document',
+    prediction: Mindee::Prediction::FinancialDocumentV1,
+  },
   "invoice" => {
     help: 'Invoice',
     prediction: Mindee::Prediction::InvoiceV4,

--- a/lib/mindee/client.rb
+++ b/lib/mindee/client.rb
@@ -164,6 +164,10 @@ module Mindee
     private
 
     def init_default_endpoints
+      @doc_configs[['mindee', Prediction::FinancialDocumentV1.name]] = DocumentConfig.new(
+        Prediction::FinancialDocumentV1,
+        [HTTP::StandardEndpoint.new('financial_document', '1', @api_key)]
+      )
       @doc_configs[['mindee', Prediction::InvoiceV4.name]] = DocumentConfig.new(
         Prediction::InvoiceV4,
         [HTTP::StandardEndpoint.new('invoices', '4', @api_key)]

--- a/lib/mindee/parsing/prediction.rb
+++ b/lib/mindee/parsing/prediction.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'prediction/custom/custom_v1'
+require_relative 'prediction/financial_document/financial_document_v1'
 require_relative 'prediction/invoice/invoice_v4'
 require_relative 'prediction/passport/passport_v1'
 require_relative 'prediction/receipt/receipt_v4'

--- a/lib/mindee/parsing/prediction/financial_document/financial_document_v1.rb
+++ b/lib/mindee/parsing/prediction/financial_document/financial_document_v1.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require_relative '../common_fields'
+require_relative '../base'
+require_relative 'invoice_line_item'
+
+module Mindee
+  module Prediction
+    # Invoice document.
+    class FinancialDocumentV1 < Prediction
+      # Locale information.
+      # @return [Mindee::Locale]
+      attr_reader :locale
+      # The nature of the invoice.
+      # @return [Mindee::TextField]
+      attr_reader :document_type
+      # The total amount with tax included.
+      # @return [Mindee::AmountField]
+      attr_reader :total_amount
+      # The total amount without the tax value.
+      # @return [Mindee::AmountField]
+      attr_reader :total_net
+      # The total tax.
+      # @return [Mindee::AmountField]
+      attr_reader :total_tax
+      # The creation date of the invoice.
+      # @return [Mindee::DateField]
+      attr_reader :date
+      # The invoice number.
+      # @return [Mindee::TextField]
+      attr_reader :invoice_number
+      # List of Reference numbers including PO number.
+      # @return [Mindee::TextField]
+      attr_reader :reference_numbers
+      # The due date of the invoice.
+      # @return [Mindee::DateField]
+      attr_reader :due_date
+      # The list of taxes.
+      # @return [Array<Mindee::TaxField>]
+      attr_reader :taxes
+      # The name of the customer.
+      # @return [Mindee::TextField]
+      attr_reader :customer_name
+      # The address of the customer.
+      # @return [Mindee::TextField]
+      attr_reader :customer_address
+      # The company registration information for the customer.
+      # @return [Array<Mindee::CompanyRegistration>]
+      attr_reader :customer_company_registrations
+      # The supplier's name.
+      # @return [Mindee::TextField]
+      attr_reader :supplier_name
+      # The supplier's address.
+      # @return [Mindee::TextField]
+      attr_reader :supplier_address
+      # The payment information.
+      # @return [Array<Mindee::PaymentDetails>]
+      attr_reader :supplier_payment_details
+      # The supplier's company registration information.
+      # @return [Array<Mindee::CompanyRegistration>]
+      attr_reader :supplier_company_registrations
+      # Line items details.
+      # @return [Array<Mindee::InvoiceLineItem>]
+      attr_reader :line_items
+      # Time as seen on the receipt in HH:MM format.
+      # @return [Mindee::TextField]
+      attr_reader :time
+      # The receipt category among predefined classes.
+      # @return [Mindee::TextField]
+      attr_reader :category
+      # The receipt sub-category among predefined classes.
+      # @return [Mindee::TextField]
+      attr_reader :subcategory
+      # A classification field, that can return 4 values : 'EXPENSE RECEIPT' ,
+      # 'CREDIT CARD RECEIPT', 'INVOICE', 'CREDIT NOTE'
+      # @return [Mindee::TextField]
+      attr_reader :document_type # rubocop:todo Lint/DuplicateMethods
+      # Total amount of tip and gratuity. Both typed and handwritten characters are supported.
+      # @return [Mindee::AmountField]
+      attr_reader :tip
+
+      # @param prediction [Hash]
+      # @param page_id [Integer, nil]
+      # rubocop:todo Metrics/MethodLength
+      def initialize(prediction, page_id) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+        super
+        prediction = fix_api_incosistencies(prediction)
+
+        @time = TextField.new(prediction['time'], page_id)
+        @category = TextField.new(prediction['category'], page_id)
+        @subcategory = TextField.new(prediction['subcategory'], page_id)
+        @document_type = TextField.new(prediction['document_type'], page_id)
+        @tip = AmountField.new(prediction['tip'], page_id)
+        @locale = Locale.new(prediction['locale'])
+        @document_type = TextField.new(prediction['document_type'], page_id)
+        @total_amount = AmountField.new(prediction['total_amount'], page_id)
+        @total_net = AmountField.new(prediction['total_net'], page_id)
+        @customer_address = TextField.new(prediction['customer_address'], page_id)
+        @customer_name = TextField.new(prediction['customer_name'], page_id)
+        @date = DateField.new(prediction['date'], page_id)
+        @due_date = DateField.new(prediction['due_date'], page_id)
+        @invoice_number = TextField.new(prediction['invoice_number'], page_id)
+        @supplier_name = TextField.new(prediction['supplier_name'], page_id)
+        @supplier_address = TextField.new(prediction['supplier_address'], page_id)
+
+        @reference_numbers = []
+        prediction['reference_numbers'].each do |item|
+          @reference_numbers.push(TextField.new(item, page_id))
+        end
+        @customer_company_registrations = []
+        prediction['customer_company_registrations'].each do |item|
+          @customer_company_registrations.push(CompanyRegistration.new(item, page_id))
+        end
+        @taxes = []
+        prediction['taxes'].each do |item|
+          @taxes.push(TaxField.new(item, page_id))
+        end
+        @supplier_payment_details = []
+        prediction['supplier_payment_details'].each do |item|
+          @supplier_payment_details.push(PaymentDetails.new(item, page_id))
+        end
+        @supplier_company_registrations = []
+        prediction['supplier_company_registrations'].each do |item|
+          @supplier_company_registrations.push(CompanyRegistration.new(item, page_id))
+        end
+
+        @total_tax = AmountField.new(
+          { value: nil, confidence: 0.0 }, page_id
+        )
+
+        @line_items = []
+        prediction['line_items'].each do |item|
+          @line_items.push(InvoiceLineItem.new(item, page_id))
+        end
+        reconstruct(page_id)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def to_s
+        customer_company_registrations = @customer_company_registrations.map(&:value).join('; ')
+        supplier_payment_details = @supplier_payment_details.map(&:to_s).join("\n                 ")
+        supplier_company_registrations = @supplier_company_registrations.map(&:to_s).join('; ')
+        reference_numbers = @reference_numbers.map(&:to_s).join(', ')
+        taxes = @taxes.join("\n       ")
+        out_str = String.new
+        out_str << "\n:Document type: #{@document_type}".rstrip
+        out_str << "\n:Category: #{@category}".rstrip
+        out_str << "\n:Subcategory: #{@subcategory}".rstrip
+        out_str << "\n:Locale: #{@locale}".rstrip
+        out_str << "\n:Date: #{@date}".rstrip
+        out_str << "\n:Due date: #{@due_date}".rstrip
+        out_str << "\n:Time: #{@time}".rstrip
+        out_str << "\n:Number: #{@invoice_number}".rstrip
+        out_str << "\n:Reference numbers: #{reference_numbers}".rstrip
+        out_str << "\n:Supplier name: #{@supplier_name}".rstrip
+        out_str << "\n:Supplier address: #{@supplier_address}".rstrip
+        out_str << "\n:Supplier company registrations: #{supplier_company_registrations}".rstrip
+        out_str << "\n:Supplier payment details: #{supplier_payment_details}".rstrip
+
+        out_str << "\n:Customer name: #{@customer_name}".rstrip
+        out_str << "\n:Customer address: #{@customer_address}".rstrip
+        out_str << "\n:Customer company registrations: #{customer_company_registrations}".rstrip
+
+        out_str << "\n:Tip: #{@tip}".rstrip
+
+        out_str << "\n:Taxes: #{taxes}".rstrip
+        out_str << "\n:Total taxes: #{@total_tax}".rstrip
+        out_str << "\n:Total net: #{@total_net}".rstrip
+        out_str << "\n:Total amount: #{@total_amount}".rstrip
+
+        out_str << line_items_to_s
+
+        out_str[1..].to_s
+      end
+
+      private
+
+      def fix_api_incosistencies(prediction)
+        # The API seems to have a typo on these fields, returns them in singular instead of plural
+        prediction['customer_company_registrations'] = prediction['customer_company_registration'] || []
+        prediction['supplier_company_registrations'] = prediction['supplier_company_registration'] || []
+
+        # The API can return this field as nil
+        prediction['supplier_payment_details'] ||= []
+
+        # The API seems to return { 'confidence' => [], 'polygon' => [], 'value' => [] }
+        # instead of { 'confidence' => nil, 'polygon' => [], 'value' => nil }
+        if prediction.dig('tip', 'value').is_a?(Array)
+          prediction['tip'] = { 'confidence' => nil, 'polygon' => [], 'value' => nil }
+        end
+
+        if prediction.dig('time', 'value').is_a?(Array)
+          prediction['time'] = { 'confidence' => nil, 'polygon' => [], 'value' => nil }
+        end
+
+        prediction
+      end
+
+      def line_items_to_s
+        line_item_separator = "#{'=' * 22} #{'=' * 8} #{'=' * 9} #{'=' * 10} #{'=' * 18} #{'=' * 36}"
+        line_items = @line_items.map(&:to_s).join("\n")
+
+        out_str = String.new
+        out_str << "\n\n:Line Items:"
+
+        return out_str if line_items.empty?
+
+        out_str << "\n#{line_item_separator}"
+        out_str << "\nCode                   QTY      Price     Amount     Tax (Rate)         Description"
+        out_str << "\n#{line_item_separator}"
+        out_str << "\n#{line_items}"
+        out_str << "\n#{line_item_separator}"
+      end
+
+      def reconstruct(page_id)
+        construct_total_tax_from_taxes(page_id)
+        return unless page_id.nil?
+
+        construct_total_excl_from_tcc_and_taxes(page_id)
+        construct_total_incl_from_taxes_plus_excl(page_id)
+        construct_total_tax_from_totals(page_id)
+      end
+
+      def construct_total_excl_from_tcc_and_taxes(page_id)
+        return if @total_amount.value.nil? || taxes.empty? || !@total_net.value.nil?
+
+        total_excl = {
+          'value' => @total_amount.value - @taxes.map(&:value).sum,
+          'confidence' => TextField.array_confidence(@taxes) * @total_amount.confidence,
+        }
+        @total_net = AmountField.new(total_excl, page_id, reconstructed: true)
+      end
+
+      def construct_total_incl_from_taxes_plus_excl(page_id)
+        return if @total_net.value.nil? || @taxes.empty? || !@total_amount.value.nil?
+
+        total_incl = {
+          'value' => @taxes.map(&:value).sum + @total_net.value,
+          'confidence' => TextField.array_confidence(@taxes) * @total_net.confidence,
+        }
+        @total_amount = AmountField.new(total_incl, page_id, reconstructed: true)
+      end
+
+      def construct_total_tax_from_taxes(page_id)
+        return if @taxes.empty?
+
+        total_tax = {
+          'value' => @taxes.map(&:value).sum,
+          'confidence' => TextField.array_confidence(@taxes),
+        }
+        return unless total_tax['value'].positive?
+
+        @total_tax = AmountField.new(total_tax, page_id, reconstructed: true)
+      end
+
+      def construct_total_tax_from_totals(page_id)
+        return if !@total_tax.value.nil? || @total_amount.value.nil? || @total_net.value.nil?
+
+        total_tax = {
+          'value' => @total_amount.value - @total_net.value,
+          'confidence' => TextField.array_confidence(@taxes),
+        }
+        return unless total_tax['value'] >= 0
+
+        @total_tax = AmountField.new(total_tax, page_id, reconstructed: true)
+      end
+    end
+  end
+end

--- a/lib/mindee/parsing/prediction/financial_document/financial_document_v1.rb
+++ b/lib/mindee/parsing/prediction/financial_document/financial_document_v1.rb
@@ -81,10 +81,8 @@ module Mindee
 
       # @param prediction [Hash]
       # @param page_id [Integer, nil]
-      # rubocop:todo Metrics/MethodLength
-      def initialize(prediction, page_id) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+      def initialize(prediction, page_id) # rubocop:todo Metrics/AbcSize
         super
-        prediction = fix_api_incosistencies(prediction)
 
         @time = TextField.new(prediction['time'], page_id)
         @category = TextField.new(prediction['category'], page_id)
@@ -134,7 +132,6 @@ module Mindee
         end
         reconstruct(page_id)
       end
-      # rubocop:enable Metrics/MethodLength
 
       def to_s
         customer_company_registrations = @customer_company_registrations.map(&:value).join('; ')
@@ -174,27 +171,6 @@ module Mindee
       end
 
       private
-
-      def fix_api_incosistencies(prediction)
-        # The API seems to have a typo on these fields, returns them in singular instead of plural
-        prediction['customer_company_registrations'] = prediction['customer_company_registration'] || []
-        prediction['supplier_company_registrations'] = prediction['supplier_company_registration'] || []
-
-        # The API can return this field as nil
-        prediction['supplier_payment_details'] ||= []
-
-        # The API seems to return { 'confidence' => [], 'polygon' => [], 'value' => [] }
-        # instead of { 'confidence' => nil, 'polygon' => [], 'value' => nil }
-        if prediction.dig('tip', 'value').is_a?(Array)
-          prediction['tip'] = { 'confidence' => nil, 'polygon' => [], 'value' => nil }
-        end
-
-        if prediction.dig('time', 'value').is_a?(Array)
-          prediction['time'] = { 'confidence' => nil, 'polygon' => [], 'value' => nil }
-        end
-
-        prediction
-      end
 
       def line_items_to_s
         line_item_separator = "#{'=' * 22} #{'=' * 8} #{'=' * 9} #{'=' * 10} #{'=' * 18} #{'=' * 36}"

--- a/lib/mindee/parsing/prediction/financial_document/invoice_line_item.rb
+++ b/lib/mindee/parsing/prediction/financial_document/invoice_line_item.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative '../common_fields/base'
+
+module Mindee
+  # Line items for invoices
+  class InvoiceLineItem
+    # @return [String] The product code referring to the item.
+    attr_reader :product_code
+    # @return [String]
+    attr_reader :description
+    # @return [Float]
+    attr_reader :quantity
+    # @return [Float]
+    attr_reader :unit_price
+    # @return [Float]
+    attr_reader :total_amount
+    # @return [Float] The item tax rate percentage.
+    attr_reader :tax_rate
+    # @return [Float]
+    attr_reader :tax_amount
+    # @return [Float]
+    attr_reader :confidence
+    # @return [Integer]
+    attr_reader :page_id
+    # @return [Mindee::Geometry::Quadrilateral]
+    attr_reader :bounding_box
+    # @return [Array<Mindee::Geometry::Polygon>]
+    attr_reader :polygon
+
+    def initialize(prediction, page_id)
+      @product_code = prediction['product_code']
+      @quantity = prediction['quantity']
+      @unit_price = prediction['unit_price']
+      @total_amount = prediction['total_amount']
+      @tax_amount = prediction['tax_amount']
+      @tax_rate = prediction['tax_rate']
+      @description = prediction['description']
+      @page_id = page_id
+    end
+
+    def to_s
+      tax = Field.float_to_string(@tax_amount)
+      tax << " (#{Field.float_to_string(@tax_rate)}%)" unless @tax_rate.nil?
+
+      description = @description.nil? ? '' : @description
+      description = "#{description[0..32]}..." if description.size > 35
+
+      out_str = String.new
+      out_str << format('%- 22s', @product_code)
+      out_str << " #{format('%- 8s', Field.float_to_string(@quantity))}"
+      out_str << " #{format('%- 9s', Field.float_to_string(@unit_price))}"
+      out_str << " #{format('%- 10s', Field.float_to_string(@total_amount))}"
+      out_str << " #{format('%- 18s', tax)}"
+      out_str << " #{description}"
+    end
+  end
+end

--- a/lib/mindee/parsing/prediction/receipt/receipt_v4.rb
+++ b/lib/mindee/parsing/prediction/receipt/receipt_v4.rb
@@ -40,6 +40,9 @@ module Mindee
       # Whether the document is an expense receipt or a credit card receipt.
       # @return [Mindee::TextField]
       attr_reader :document_type
+      # Total amount of tip and gratuity. Both typed and handwritten characters are supported.
+      # @return [Mindee::AmountField]
+      attr_reader :tip
 
       # @param prediction [Hash]
       # @param page_id [Integer, nil]

--- a/spec/data.rb
+++ b/spec/data.rb
@@ -4,6 +4,7 @@ DATA_DIR = File.join(__dir__, 'data').freeze
 DIR_CUSTOM_V1 = File.join(DATA_DIR, 'custom', 'response_v1').freeze
 DIR_INVOICE_V4 = File.join(DATA_DIR, 'invoice', 'response_v4').freeze
 DIR_RECEIPT_V4 = File.join(DATA_DIR, 'receipt', 'response_v4').freeze
+DIR_FINANCIAL_DOCUMENT_V1 = File.join(DATA_DIR, 'financial_document', 'response_v1').freeze
 DIR_PASSPORT_V1 = File.join(DATA_DIR, 'passport', 'response_v1').freeze
 DIR_EU_LICENSE_PLATE_V1 = File.join(DATA_DIR, 'eu', 'license_plate', 'response_v1').freeze
 DIR_SHIPPING_CONTAINER_V1 = File.join(DATA_DIR, 'shipping_container', 'response_v1').freeze

--- a/spec/document/documents_spec.rb
+++ b/spec/document/documents_spec.rb
@@ -16,6 +16,73 @@ describe Mindee::Document do
     File.read(File.join(dir_path, file_name)).strip
   end
 
+  context 'A FinancialDocumentV1' do
+    context 'when processing an invoice' do
+      it 'should load an empty document prediction' do
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'empty.json')
+        document = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document'])
+        expect(document.inference.product.type).to eq('standard')
+        prediction = document.inference.prediction
+        expect(prediction.invoice_number.value).to be_nil
+        expect(prediction.invoice_number.polygon).to be_empty
+        expect(prediction.invoice_number.bounding_box).to be_nil
+        expect(prediction.date.value).to be_nil
+        expect(prediction.date.page_id).to eq(0)
+      end
+
+      it 'should load a complete document prediction' do
+        to_string = read_file(DIR_FINANCIAL_DOCUMENT_V1, 'summary_full_invoice.rst')
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'complete_invoice.json')
+        document = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document'])
+        prediction = document.inference.prediction
+        expect(prediction.invoice_number.bounding_box.top_left.x).to eq(prediction.invoice_number.polygon[0][0])
+        expect(prediction.date.value).to eq('2019-02-11')
+        expect(prediction.due_date.value).to eq('2019-02-26')
+        expect(prediction.due_date.page_id).to eq(0)
+        expect(document.to_s).to eq(to_string)
+      end
+
+      it 'should load a complete page 0 prediction' do
+        to_string = read_file(DIR_FINANCIAL_DOCUMENT_V1, 'summary_page0_invoice.rst')
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'complete_invoice.json')
+        document = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document'])
+        page = document.inference.pages[0]
+        expect(page.orientation.value).to eq(0)
+        expect(page.prediction.due_date.page_id).to eq(0)
+        expect(page.to_s).to eq(to_string)
+      end
+    end
+
+    context 'when processing a receipt' do
+      it 'should load an empty document prediction' do
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'empty.json')
+        inference = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document']).inference
+        expect(inference.product.type).to eq('standard')
+        expect(inference.prediction.date.value).to be_nil
+        expect(inference.prediction.date.page_id).to eq(0)
+        expect(inference.prediction.time.value).to be_nil
+      end
+
+      it 'should load a complete document prediction' do
+        to_string = read_file(DIR_FINANCIAL_DOCUMENT_V1, 'summary_full_receipt.rst')
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'complete_receipt.json')
+        document = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document'])
+        expect(document.inference.prediction.date.page_id).to eq(0)
+        expect(document.inference.prediction.date.value).to eq('2014-07-07')
+        expect(document.to_s).to eq(to_string)
+      end
+
+      it 'should load a complete page 0 prediction' do
+        to_string = read_file(DIR_FINANCIAL_DOCUMENT_V1, 'summary_page0_receipt.rst')
+        response = load_json(DIR_FINANCIAL_DOCUMENT_V1, 'complete_receipt.json')
+        document = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document'])
+        page = document.inference.pages[0]
+        expect(page.orientation.value).to eq(0)
+        expect(page.prediction.date.page_id).to eq(0)
+        expect(page.to_s).to eq(to_string)
+      end
+    end
+  end
   context 'An Invoice V4' do
     it 'should load an empty document prediction' do
       response = load_json(DIR_INVOICE_V4, 'empty.json')

--- a/spec/document/documents_spec.rb
+++ b/spec/document/documents_spec.rb
@@ -27,7 +27,7 @@ describe Mindee::Document do
         expect(prediction.invoice_number.polygon).to be_empty
         expect(prediction.invoice_number.bounding_box).to be_nil
         expect(prediction.date.value).to be_nil
-        expect(prediction.date.page_id).to eq(0)
+        expect(prediction.date.page_id).to be_nil
       end
 
       it 'should load a complete document prediction' do
@@ -59,7 +59,7 @@ describe Mindee::Document do
         inference = Mindee::Document.new(Mindee::Prediction::FinancialDocumentV1, response['document']).inference
         expect(inference.product.type).to eq('standard')
         expect(inference.prediction.date.value).to be_nil
-        expect(inference.prediction.date.page_id).to eq(0)
+        expect(inference.prediction.date.page_id).to be_nil
         expect(inference.prediction.time.value).to be_nil
       end
 


### PR DESCRIPTION
## Description

Adds support for the FinancialDocument endpoint. 

## How Has This Been Tested
Tested locally and with my API key.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**Author: @oriolgual**
