### PR TITLE
:sparkles: add a specific class for classifications, which are never nil

### DIFF
--- a/lib/mindee/parsing/prediction/common_fields.rb
+++ b/lib/mindee/parsing/prediction/common_fields.rb
@@ -2,6 +2,7 @@
 
 require_relative 'common_fields/amount'
 require_relative 'common_fields/base'
+require_relative 'common_fields/classification'
 require_relative 'common_fields/company_registration'
 require_relative 'common_fields/date'
 require_relative 'common_fields/locale'

--- a/lib/mindee/parsing/prediction/common_fields/classification.rb
+++ b/lib/mindee/parsing/prediction/common_fields/classification.rb
@@ -3,10 +3,10 @@
 require_relative 'base'
 
 module Mindee
-  # Represents basic text information.
-  class TextField < Field
+  # Represents a classifier value.
+  class ClassificationField < Field
     # Value as String
-    # @return [String, nil]
+    # @return [String]
     attr_reader :value
   end
 end

--- a/lib/mindee/parsing/prediction/custom/custom_v1.rb
+++ b/lib/mindee/parsing/prediction/custom/custom_v1.rb
@@ -8,10 +8,10 @@ module Mindee
     # Custom document object.
     class CustomV1 < Prediction
       # All value fields in the document
-      # @return [Hash<Symbol, Mindee::ListField>]
+      # @return [Hash<Symbol, Mindee::Custom::ListField>]
       attr_reader :fields
       # All classifications in the document
-      # @return [Hash<Symbol, Mindee::ClassificationField>]
+      # @return [Hash<Symbol, Mindee::Custom::ClassificationField>]
       attr_reader :classifications
 
       # @param prediction [Hash]
@@ -46,9 +46,9 @@ module Mindee
         # Here we use the fact that only value lists have the 'values' attribute.
 
         if field_prediction.key? 'values'
-          @fields[field_sym] = ListField.new(field_prediction, page_id)
+          @fields[field_sym] = Custom::ListField.new(field_prediction, page_id)
         elsif field_prediction.key? 'value'
-          @classifications[field_sym] = ClassificationField.new(field_prediction)
+          @classifications[field_sym] = Custom::ClassificationField.new(field_prediction)
         else
           throw 'Unknown API field type'
         end

--- a/lib/mindee/parsing/prediction/custom/fields.rb
+++ b/lib/mindee/parsing/prediction/custom/fields.rb
@@ -1,91 +1,93 @@
 # frozen_string_literal: true
 
 module Mindee
-  # Document classification (custom docs)
-  class ClassificationField
-    # The classification value
-    # @return [String]
-    attr_reader :value
-    # The confidence score, value will be between 0.0 and 1.0
-    # @return [Float]
-    attr_accessor :confidence
+  module Custom
+    # Document classification (custom docs)
+    class ClassificationField
+      # The classification value
+      # @return [String]
+      attr_reader :value
+      # The confidence score, value will be between 0.0 and 1.0
+      # @return [Float]
+      attr_accessor :confidence
 
-    # @param prediction [Hash]
-    def initialize(prediction)
-      @value = prediction['value']
-      @confidence = prediction['confidence']
-    end
+      # @param prediction [Hash]
+      def initialize(prediction)
+        @value = prediction['value']
+        @confidence = prediction['confidence']
+      end
 
-    def to_s
-      @value
-    end
-  end
-
-  # Field in a list.
-  class ListFieldItem
-    # The confidence score, value will be between 0.0 and 1.0
-    # @return [Float]
-    attr_accessor :confidence
-    # @return [Mindee::Geometry::Quadrilateral]
-    attr_reader :bounding_box
-    # @return [Mindee::Geometry::Polygon]
-    attr_reader :polygon
-    attr_reader :content
-
-    # @param prediction [Hash]
-    def initialize(prediction)
-      @content = prediction['content']
-      @confidence = prediction['confidence']
-      @polygon = Geometry.polygon_from_prediction(prediction['polygon'])
-      @bounding_box = Geometry.get_bounding_box(@polygon) unless @polygon.nil? || @polygon.empty?
-    end
-
-    # @return [String]
-    def to_s
-      @content.to_s
-    end
-  end
-
-  # Field where actual values are kept in a list (custom docs).
-  class ListField
-    # @return [Array<Mindee::ListFieldItem>]
-    attr_reader :values
-    # @return [Integer, nil]
-    attr_reader :page_id
-    # true if the field was reconstructed or computed using other fields.
-    # @return [Boolean]
-    attr_reader :reconstructed
-    # The confidence score, value will be between 0.0 and 1.0
-    # @return [Float]
-    attr_accessor :confidence
-
-    # @param prediction [Hash]
-    # @param page_id [Integer, nil]
-    # @param reconstructed [Boolean]
-    def initialize(prediction, page_id, reconstructed: false)
-      @values = []
-      @confidence = prediction['confidence']
-      @page_id = page_id || prediction['page_id']
-      @reconstructed = reconstructed
-
-      prediction['values'].each do |field|
-        @values.push(ListFieldItem.new(field))
+      def to_s
+        @value
       end
     end
 
-    # @return [Array]
-    def contents_list
-      @values.map(&:content)
+    # Field in a list.
+    class ListFieldItem
+      # The confidence score, value will be between 0.0 and 1.0
+      # @return [Float]
+      attr_accessor :confidence
+      # @return [Mindee::Geometry::Quadrilateral]
+      attr_reader :bounding_box
+      # @return [Mindee::Geometry::Polygon]
+      attr_reader :polygon
+      attr_reader :content
+
+      # @param prediction [Hash]
+      def initialize(prediction)
+        @content = prediction['content']
+        @confidence = prediction['confidence']
+        @polygon = Geometry.polygon_from_prediction(prediction['polygon'])
+        @bounding_box = Geometry.get_bounding_box(@polygon) unless @polygon.nil? || @polygon.empty?
+      end
+
+      # @return [String]
+      def to_s
+        @content.to_s
+      end
     end
 
-    # @return [String]
-    def contents_str(separator: ' ')
-      @values.map(&:to_s).join(separator)
-    end
+    # Field where actual values are kept in a list (custom docs).
+    class ListField
+      # @return [Array<Mindee::ListFieldItem>]
+      attr_reader :values
+      # @return [Integer, nil]
+      attr_reader :page_id
+      # true if the field was reconstructed or computed using other fields.
+      # @return [Boolean]
+      attr_reader :reconstructed
+      # The confidence score, value will be between 0.0 and 1.0
+      # @return [Float]
+      attr_accessor :confidence
 
-    # @return [String]
-    def to_s
-      contents_str(separator: ' ')
+      # @param prediction [Hash]
+      # @param page_id [Integer, nil]
+      # @param reconstructed [Boolean]
+      def initialize(prediction, page_id, reconstructed: false)
+        @values = []
+        @confidence = prediction['confidence']
+        @page_id = page_id || prediction['page_id']
+        @reconstructed = reconstructed
+
+        prediction['values'].each do |field|
+          @values.push(ListFieldItem.new(field))
+        end
+      end
+
+      # @return [Array]
+      def contents_list
+        @values.map(&:content)
+      end
+
+      # @return [String]
+      def contents_str(separator: ' ')
+        @values.map(&:to_s).join(separator)
+      end
+
+      # @return [String]
+      def to_s
+        contents_str(separator: ' ')
+      end
     end
   end
 end

--- a/lib/mindee/parsing/prediction/invoice/invoice_v4.rb
+++ b/lib/mindee/parsing/prediction/invoice/invoice_v4.rb
@@ -12,7 +12,7 @@ module Mindee
       # @return [Mindee::Locale]
       attr_reader :locale
       # The nature of the invoice.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :document_type
       # The total amount with tax included.
       # @return [Mindee::AmountField]
@@ -68,7 +68,7 @@ module Mindee
       def initialize(prediction, page_id)
         super
         @locale = Locale.new(prediction['locale'])
-        @document_type = TextField.new(prediction['document_type'], page_id)
+        @document_type = ClassificationField.new(prediction['document_type'], page_id)
         @total_amount = AmountField.new(prediction['total_amount'], page_id)
         @total_net = AmountField.new(prediction['total_net'], page_id)
         @customer_address = TextField.new(prediction['customer_address'], page_id)

--- a/lib/mindee/parsing/prediction/receipt/receipt_v4.rb
+++ b/lib/mindee/parsing/prediction/receipt/receipt_v4.rb
@@ -32,13 +32,13 @@ module Mindee
       # @return [Mindee::TextField]
       attr_reader :time
       # The receipt category among predefined classes.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :category
       # The receipt sub-category among predefined classes.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :subcategory
       # Whether the document is an expense receipt or a credit card receipt.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :document_type
       # Total amount of tip and gratuity. Both typed and handwritten characters are supported.
       # @return [Mindee::AmountField]
@@ -54,9 +54,9 @@ module Mindee
         @total_tax = AmountField.new(prediction['total_tax'], page_id)
         @tip = AmountField.new(prediction['tip'], page_id)
         @date = DateField.new(prediction['date'], page_id)
-        @category = TextField.new(prediction['category'], page_id)
-        @subcategory = TextField.new(prediction['subcategory'], page_id)
-        @document_type = TextField.new(prediction['document_type'], page_id)
+        @category = ClassificationField.new(prediction['category'], page_id)
+        @subcategory = ClassificationField.new(prediction['subcategory'], page_id)
+        @document_type = ClassificationField.new(prediction['document_type'], page_id)
         @supplier = TextField.new(prediction['supplier'], page_id)
         @time = TextField.new(prediction['time'], page_id)
         @taxes = []

--- a/lib/mindee/parsing/prediction/receipt/receipt_v5.rb
+++ b/lib/mindee/parsing/prediction/receipt/receipt_v5.rb
@@ -12,13 +12,13 @@ module Mindee
       # @return [Mindee::Locale]
       attr_reader :locale
       # The receipt category among predefined classes.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :category
       # The receipt sub category among predefined classes for transport and food.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :subcategory
       # Whether the document is an expense receipt or a credit card receipt.
-      # @return [Mindee::TextField]
+      # @return [Mindee::ClassificationField]
       attr_reader :document_type
       # The date the purchase was made.
       # @return [Mindee::DateField]
@@ -62,9 +62,9 @@ module Mindee
       def initialize(prediction, page_id)
         super
         @locale = Locale.new(prediction['locale'], page_id)
-        @category = TextField.new(prediction['category'], page_id)
-        @subcategory = TextField.new(prediction['subcategory'], page_id)
-        @document_type = TextField.new(prediction['document_type'], page_id)
+        @category = ClassificationField.new(prediction['category'], page_id)
+        @subcategory = ClassificationField.new(prediction['subcategory'], page_id)
+        @document_type = ClassificationField.new(prediction['document_type'], page_id)
         @date = DateField.new(prediction['date'], page_id)
         @time = TextField.new(prediction['time'], page_id)
         @total_amount = AmountField.new(prediction['total_amount'], page_id)


### PR DESCRIPTION
## Description
Classification fields are never nil, make a simple class to represent those.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
