### PR TITLE
:recycle: harmonize all_names argument with other libraries

### DIFF
--- a/bin/mindee.rb
+++ b/bin/mindee.rb
@@ -71,8 +71,8 @@ def ots_subcommand(command, options)
     opt.on('-k [KEY]', '--key [KEY]', 'API key for the endpoint') do |v|
       options[:api_key] = v
     end
-    opt.on('-w', '--with-words', 'Include words in response') do |v|
-      options[:include_words] = v
+    opt.on('-w', '--all-words', 'Include words in response') do |v|
+      options[:all_words] = v
     end
     opt.on('-c', '--cut-pages', "Cut document pages") do |v|
       options[:cut_pages] = v
@@ -83,8 +83,8 @@ end
 def custom_subcommand(options)
   OptionParser.new do |opt|
     opt.banner = "Usage: custom [options] ENDPOINT_NAME FILE"
-    opt.on('-w', '--with-words', 'Include words in response') do |v|
-      options[:include_words] = v
+    opt.on('-w', '--all-words', 'Include words in response') do |v|
+      options[:all_words] = v
     end
     opt.on('-c', '--cut-pages', "Don't cut document pages") do |v|
       options[:cut_pages] = v

--- a/lib/mindee/client.rb
+++ b/lib/mindee/client.rb
@@ -31,7 +31,7 @@ module Mindee
     #  standard (off the shelf) endpoint.
     #  Do not set for standard (off the shelf) endpoints.
     #
-    # @param include_words [Boolean] Whether to include the full text for each page.
+    # @param all_words [Boolean] Whether to include the full text for each page.
     #  This performs a full OCR operation on the server and will increase response time.
     #
     # @param close_file [Boolean] Whether to `close()` the file after parsing it.
@@ -55,7 +55,7 @@ module Mindee
       prediction_class,
       endpoint_name: '',
       account_name: '',
-      include_words: false,
+      all_words: false,
       close_file: true,
       page_options: nil,
       cropper: false
@@ -63,7 +63,7 @@ module Mindee
 
       @doc_config = find_doc_config(prediction_class, endpoint_name, account_name)
       input_doc.process_pdf(page_options) if !page_options.nil? && input_doc.pdf?
-      Mindee::ApiResponse.new(prediction_class, @doc_config.predict(input_doc, include_words, close_file, cropper))
+      Mindee::ApiResponse.new(prediction_class, @doc_config.predict(input_doc, all_words, close_file, cropper))
     end
 
     # Enqueue a document for async parsing
@@ -80,7 +80,7 @@ module Mindee
     #  standard (off the shelf) endpoint.
     #  Do not set for standard (off the shelf) endpoints.
     #
-    # @param include_words [Boolean] Whether to include the full text for each page.
+    # @param all_words [Boolean] Whether to extract all the words on each page.
     #  This performs a full OCR operation on the server and will increase response time.
     #
     # @param close_file [Boolean] Whether to `close()` the file after parsing it.
@@ -103,7 +103,7 @@ module Mindee
       prediction_class,
       endpoint_name: '',
       account_name: '',
-      include_words: false,
+      all_words: false,
       close_file: true,
       page_options: nil,
       cropper: false
@@ -111,7 +111,7 @@ module Mindee
       @doc_config = find_doc_config(prediction_class, endpoint_name, account_name)
       input_doc.process_pdf(page_options) if !page_options.nil? && input_doc.pdf?
       Mindee::ApiResponse.new(prediction_class,
-                              @doc_config.predict_async(input_doc, include_words, close_file, cropper))
+                              @doc_config.predict_async(input_doc, all_words, close_file, cropper))
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/lib/mindee/document_config.rb
+++ b/lib/mindee/document_config.rb
@@ -22,13 +22,13 @@ module Mindee
 
     # Call the prediction API.
     # @param input_doc [Mindee::LocalInputSource]
-    # @param include_words [Boolean]
+    # @param all_words [Boolean]
     # @param close_file [Boolean]
     # @param cropper [Boolean]
     # @return [Hash]
-    def predict(input_doc, include_words, close_file, cropper)
+    def predict(input_doc, all_words, close_file, cropper)
       check_api_key
-      response = predict_request(input_doc, include_words, close_file, cropper)
+      response = predict_request(input_doc, all_words, close_file, cropper)
       hashed_response = JSON.parse(response.body, object_class: Hash)
       return hashed_response if (200..299).include?(response.code.to_i)
 
@@ -41,9 +41,9 @@ module Mindee
     # @param close_file [Boolean]
     # @param cropper [Boolean]
     # @return [Hash]
-    def predict_async(input_doc, include_words, close_file, cropper)
+    def predict_async(input_doc, all_words, close_file, cropper)
       check_api_key
-      response = predict_async_request(input_doc, include_words, close_file, cropper)
+      response = predict_async_request(input_doc, all_words, close_file, cropper)
       hashed_response = JSON.parse(response.body, object_class: Hash)
       return hashed_response if (200..299).include?(response.code.to_i)
 
@@ -67,21 +67,21 @@ module Mindee
     private
 
     # @param input_doc [Mindee::LocalInputSource]
-    # @param include_words [Boolean]
+    # @param all_words [Boolean]
     # @param close_file [Boolean]
     # @param cropper [Boolean]
     # @return [Net::HTTPResponse]
-    def predict_request(input_doc, include_words, close_file, cropper)
-      @endpoint.predict_req_post(input_doc, include_words: include_words, close_file: close_file, cropper: cropper)
+    def predict_request(input_doc, all_words, close_file, cropper)
+      @endpoint.predict_req_post(input_doc, all_words: all_words, close_file: close_file, cropper: cropper)
     end
 
     # @param input_doc [Mindee::LocalInputSource]
-    # @param include_words [Boolean]
+    # @param all_words [Boolean]
     # @param close_file [Boolean]
     # @param cropper [Boolean]
     # @return [Net::HTTPResponse]
-    def predict_async_request(input_doc, include_words, close_file, cropper)
-      @endpoint.predict_async_req_post(input_doc, include_words, close_file, cropper)
+    def predict_async_request(input_doc, all_words, close_file, cropper)
+      @endpoint.predict_async_req_post(input_doc, all_words, close_file, cropper)
     end
 
     # @param job_id [String]

--- a/lib/mindee/http/endpoint.rb
+++ b/lib/mindee/http/endpoint.rb
@@ -33,11 +33,11 @@ module Mindee
       end
 
       # @param input_doc [Mindee::LocalInputSource]
-      # @param include_words [Boolean]
+      # @param all_words [Boolean]
       # @param close_file [Boolean]
       # @param cropper [Boolean]
       # @return [Net::HTTPResponse]
-      def predict_req_post(input_doc, include_words: false, close_file: true, cropper: false)
+      def predict_req_post(input_doc, all_words: false, close_file: true, cropper: false)
         uri = URI("#{@url_root}/predict")
 
         params = {}
@@ -53,7 +53,7 @@ module Mindee
         form_data = {
           'document' => input_doc.read_document(close: close_file),
         }
-        form_data.push ['include_mvision', 'true'] if include_words
+        form_data.push ['include_mvision', 'true'] if all_words
 
         req.set_form(form_data, 'multipart/form-data')
 
@@ -63,11 +63,11 @@ module Mindee
       end
 
       # @param input_doc [Mindee::LocalInputSource]
-      # @param include_words [Boolean]
+      # @param all_words [Boolean]
       # @param close_file [Boolean]
       # @param cropper [Boolean]
       # @return [Net::HTTPResponse]
-      def predict_async_req_post(input_doc, include_words, close_file, cropper)
+      def predict_async_req_post(input_doc, all_words, close_file, cropper)
         uri = URI("#{@url_root}/predict_async")
 
         params = {}
@@ -83,7 +83,7 @@ module Mindee
         form_data = {
           'document' => input_doc.read_document(close: close_file),
         }
-        form_data.push ['include_mvision', 'true'] if include_words
+        form_data.push ['include_mvision', 'true'] if all_words
 
         req.set_form(form_data, 'multipart/form-data')
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -67,7 +67,7 @@ describe Mindee::Client do
       file = File.open("#{DATA_DIR}/receipt/receipt.jpg", 'rb')
       doc = mindee_client1.doc_from_file(file, 'receipt.jpg')
       expect do
-        mindee_client1.parse(doc, Mindee::Prediction::ReceiptV4, include_words: false, close_file: true)
+        mindee_client1.parse(doc, Mindee::Prediction::ReceiptV4, all_words: false, close_file: true)
       end.to raise_error Mindee::Parsing::Error
     end
 


### PR DESCRIPTION
## Description
rename `include_words` to `all_words` to harmonize with other libraries.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
