### PR TITLE
:bug: fix broken pdf repacking

### DIFF
--- a/lib/mindee/http/endpoint.rb
+++ b/lib/mindee/http/endpoint.rb
@@ -99,7 +99,7 @@ module Mindee
         form_data = if input_source.is_a?(Mindee::Input::Source::UrlInputSource)
                       [['document', input_source.url]]
                     else
-                      [['document', input_source.read_document(close: close_file)]]
+                      [input_source.read_document(close: close_file)]
                     end
         form_data.push ['include_mvision', 'true'] if all_words
 
@@ -130,7 +130,7 @@ module Mindee
         form_data = if input_source.is_a?(Mindee::Input::Source::UrlInputSource)
                       [['document', input_source.url]]
                     else
-                      [['document', input_source.read_document(close: close_file)]]
+                      [input_source.read_document(close: close_file)]
                     end
         form_data.push ['include_mvision', 'true'] if all_words
 

--- a/lib/mindee/input/sources.rb
+++ b/lib/mindee/input/sources.rb
@@ -49,9 +49,13 @@ module Mindee
         # @param close [Boolean]
         def read_document(close: true)
           @io_stream.seek(0)
+          # Avoids needlessly re-packing some files
+          immediate = (Marcel::MimeType.for @io_stream).to_s == 'application/pdf'
           data = @io_stream.read
           @io_stream.close if close
-          [data].pack('m')
+          return ['document', data, { filename: @filename }] if immediate
+
+          ['document', [data].pack('m'), { filename: @filename }]
         end
       end
 

--- a/lib/mindee/input/sources.rb
+++ b/lib/mindee/input/sources.rb
@@ -38,7 +38,7 @@ module Mindee
         end
 
         def pdf?
-          @file_mimetype == 'application/pdf'
+          @file_mimetype.to_s == 'application/pdf'
         end
 
         def process_pdf(options)
@@ -50,10 +50,9 @@ module Mindee
         def read_document(close: true)
           @io_stream.seek(0)
           # Avoids needlessly re-packing some files
-          immediate = (Marcel::MimeType.for @io_stream).to_s == 'application/pdf'
           data = @io_stream.read
           @io_stream.close if close
-          return ['document', data, { filename: @filename }] if immediate
+          return ['document', data, { filename: @filename }] if pdf?
 
           ['document', [data].pack('m'), { filename: @filename }]
         end

--- a/spec/input/files_handling_spec.rb
+++ b/spec/input/files_handling_spec.rb
@@ -10,7 +10,7 @@ describe Mindee::Input::Source::LocalInputSource do
       file = File.join(DATA_DIR, 'receipt/receipt.jpg')
       input = Mindee::Input::Source::PathInputSource.new(file)
       read_f = input.read_document
-      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+      expect(read_f[1]).to eq(Base64.encode64(File.read(file)))
     end
   end
 
@@ -19,49 +19,68 @@ describe Mindee::Input::Source::LocalInputSource do
       file = File.join(DATA_DIR, 'receipt/receipt.jpga')
       input = Mindee::Input::Source::PathInputSource.new(file)
       read_f = input.read_document
-      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+      expect(read_f[1]).to eq(Base64.encode64(File.read(file)))
     end
   end
-
 
   context 'A heic input file' do
     it 'should be converted as a valid byte64 string' do
       file = File.join(DATA_DIR, 'receipt/receipt.heic')
       input = Mindee::Input::Source::PathInputSource.new(file)
       read_f = input.read_document
-      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+      expect(read_f[1]).to eq(Base64.encode64(File.read(file)))
     end
   end
-
 
   context 'A tif input file' do
     it 'should be converted as a valid byte64 string' do
       file = File.join(DATA_DIR, 'receipt/receipt.tif')
       input = Mindee::Input::Source::PathInputSource.new(file)
       read_f = input.read_document
-      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+      expect(read_f[1]).to eq(Base64.encode64(File.read(file)))
     end
   end
-
 
   context 'A tiff input file' do
     it 'should be converted as a valid byte64 string' do
       file = File.join(DATA_DIR, 'receipt/receipt.tiff')
       input = Mindee::Input::Source::PathInputSource.new(file)
       read_f = input.read_document
-      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+      expect(read_f[1]).to eq(Base64.encode64(File.read(file)))
     end
   end
-
 
   context 'A txt input file' do
     it 'should be converted as a valid byte64 string' do
       file = File.join(DATA_DIR, 'receipt/receipt.txt')
-      input = Mindee::Input::Source::Base64InputSource.new(open(file).read, "receipt.txt")
+      input = Mindee::Input::Source::Base64InputSource.new(File.read(file), 'receipt.txt')
       read_f = input.read_document
-      expect(read_f[1].gsub("\n",'')).to eq(open(file).read.gsub("\n",''))
+      # NOTE: pack() & Base64.encodebase64 inputs have different rules for line breaks
+      # which also differ from the ones in the base file. For all intents and purposes,
+      # we can ignore them.
+      expect(read_f[1].gsub("\n", '')).to eq(File.read(file).gsub("\n", ''))
     end
   end
 
-  
+  context 'A standard pdf input file' do
+    it 'should not be converted' do
+      file = File.join(DATA_DIR, 'pdf/not_blank_image_only.pdf')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      file_contents = File.read(file)
+      expect(read_f[1]).to_not eq(Base64.encode64(file_contents))
+      expect(Base64.decode64(read_f[1])).to eq(Base64.decode64(file_contents))
+    end
+  end
+
+  context 'A valid written pdf input file' do
+    it 'should not be converted' do
+      file = File.join(DATA_DIR, 'pdf/valid_exported.pdf')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      file_contents = File.read(file)
+      expect(read_f[1]).to_not eq(Base64.encode64(file_contents))
+      expect(Base64.decode64(read_f[1])).to eq(Base64.decode64(file_contents))
+    end
+  end
 end

--- a/spec/input/files_handling_spec.rb
+++ b/spec/input/files_handling_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'mindee/input/sources'
+require 'base64'
+require_relative '../data'
+
+describe Mindee::Input::Source::LocalInputSource do
+  context 'An jpg input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.jpg')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+    end
+  end
+
+  context 'A jpga input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.jpga')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+    end
+  end
+
+
+  context 'A heic input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.heic')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+    end
+  end
+
+
+  context 'A tif input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.tif')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+    end
+  end
+
+
+  context 'A tiff input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.tiff')
+      input = Mindee::Input::Source::PathInputSource.new(file)
+      read_f = input.read_document
+      expect(read_f[1]).to eq(Base64.encode64(open(file).read))
+    end
+  end
+
+
+  context 'A txt input file' do
+    it 'should be converted as a valid byte64 string' do
+      file = File.join(DATA_DIR, 'receipt/receipt.txt')
+      input = Mindee::Input::Source::Base64InputSource.new(open(file).read, "receipt.txt")
+      read_f = input.read_document
+      expect(read_f[1].gsub("\n",'')).to eq(open(file).read.gsub("\n",''))
+    end
+  end
+
+  
+end

--- a/spec/input/sources_spec.rb
+++ b/spec/input/sources_spec.rb
@@ -4,7 +4,7 @@ require 'mindee/input/sources'
 
 require_relative '../data'
 
-describe Mindee::Input::Source::LocalInputSource do
+describe Mindee::Input::Source do
   context 'An image input file' do
     it 'should load a JPEG from a path' do
       input = Mindee::Input::Source::PathInputSource.new(File.join(DATA_DIR, 'receipt/receipt.jpg'))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Conversion to `base64` object from pdf inputs will sometime break due to conflicting `mime-type` detection. Fixes the issue by immediately sending files if they are valid pdf files.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
