### PR TITLE
:bug: fix missing `page_id` attribute for newer custom builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _test.rb
 /vendor
 /mindee-*/
 local-test
+local_test/
 
 # Used by dotenv library to load environment variables.
 .env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - '.git/**/*'
     - 'bin/*'
     - _test.rb
+    - local_test/*
 
   TargetRubyVersion: 2.6
   SuggestExtensions: false

--- a/bin/mindee.rb
+++ b/bin/mindee.rb
@@ -157,7 +157,7 @@ global_parser = OptionParser.new do | opts |
 end
 
 command = ARGV.shift
-if !DOCUMENTS.has_key?(command)
+if !DOCUMENTS.include?(command)
   abort(global_parser.help)
 end
 doc_class = DOCUMENTS[command][:doc_class]

--- a/lib/mindee.rb
+++ b/lib/mindee.rb
@@ -5,9 +5,6 @@ require 'mindee/client'
 module Mindee
   # Mindee internal http module.
   module HTTP
-    # Global Mindee HTTP error handler.
-    class HttpError < StandardError
-    end
   end
 
   # PDF-specific operations.

--- a/lib/mindee/http/error.rb
+++ b/lib/mindee/http/error.rb
@@ -73,7 +73,7 @@ module Mindee
       class MindeeHttpError < StandardError
         # @return [String]
         attr_reader :status_code
-        # @return [String]
+        # @return [Integer]
         attr_reader :api_code
         # @return [String]
         attr_reader :api_details

--- a/lib/mindee/parsing/common/api_response.rb
+++ b/lib/mindee/parsing/common/api_response.rb
@@ -95,7 +95,7 @@ module Mindee
         attr_reader :job
         # @return [Mindee::Parsing::Common::ApiRequest]
         attr_reader :api_request
-        # @return [String]
+        # @return [Hash]
         attr_reader :raw_http
 
         # @param product_class [Class<Mindee::Product>]

--- a/lib/mindee/parsing/custom/list_field.rb
+++ b/lib/mindee/parsing/custom/list_field.rb
@@ -56,9 +56,7 @@ module Mindee
           @reconstructed = reconstructed
 
           prediction['values'].each do |field|
-            if (field.include?("page_id"))
-              @page_id = field["page_id"]
-            end
+            @page_id = field['page_id'] if field.include?('page_id')
             @values.push(ListFieldItem.new(field))
           end
         end

--- a/lib/mindee/parsing/custom/list_field.rb
+++ b/lib/mindee/parsing/custom/list_field.rb
@@ -48,10 +48,17 @@ module Mindee
         def initialize(prediction, page_id, reconstructed: false)
           @values = []
           @confidence = prediction['confidence']
-          @page_id = page_id || prediction['page_id']
+          @page_id = if page_id.nil?
+                       prediction.include?('page_id') ? prediction['page_id'] : nil
+                     else
+                       page_id
+                     end
           @reconstructed = reconstructed
 
           prediction['values'].each do |field|
+            if (field.include?("page_id"))
+              @page_id = field["page_id"]
+            end
             @values.push(ListFieldItem.new(field))
           end
         end

--- a/spec/http/error_spec.rb
+++ b/spec/http/error_spec.rb
@@ -33,7 +33,7 @@ describe Mindee::HTTP::Error do
       end.to raise_error Mindee::HTTP::Error::MindeeHttpClientError
     end
 
-    # NOTE: No reliable UT each HTTP errorfor ruby as the only semi-reliable http mock lib (Webmock) isn't compatible
+    # NOTE: No reliable UT each HTTP error for ruby as the only semi-reliable http mock lib (Webmock) isn't compatible
     # with multipart/form-data yet
     # TODO: fix when this is patched: https://github.com/bblimke/webmock/pull/791
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :bug: newer custom-builds lost their `page_id` attributes, this fixes it
* :recycle: cleanup superfluous code
* :recycle: homogenize some syntax

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
