### PR TITLE
:sparkles: add support for multireceipts extraction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Install Ghostscript on macOS
       if: runner.os == 'macOS'
       run: brew install ghostscript
-    - name: Change ImageMagick security policy
+    - name: Change ImageMagick security policy on Ubuntu
+      if: runner.os == 'Linux'
       run: |
         DQT='"'
         SRC="rights=${DQT}none${DQT} pattern=${DQT}PDF${DQT}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,12 @@ jobs:
     - name: Install Ghostscript on macOS
       if: runner.os == 'macOS'
       run: brew install ghostscript
+    - name: Change ImageMagick security policy
+      run: |
+        DQT='"'
+        SRC="rights=${DQT}none${DQT} pattern=${DQT}PDF${DQT}"
+        RPL="rights=${DQT}read|write${DQT} pattern=${DQT}PDF${DQT}"
+        sudo sed -i "s/$SRC/$RPL/" /etc/ImageMagick-6/policy.xml
 
     - name: Run Rspec
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - "3.1"
           - "3.2"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -32,6 +32,14 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+
+    - name: Install Ghostscript on Ubuntu
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y ghostscript
+
+    - name: Install Ghostscript on macOS
+      if: runner.os == 'macOS'
+      run: brew install ghostscript
 
     - name: Run Rspec
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get install -y ghostscript
 
-    - name: Install Ghostscript on macOS
+    - name: Install Ghostscript and ImageMagick on macOS
       if: runner.os == 'macOS'
-      run: brew install ghostscript
+      run: brew install ghostscript imagemagick
     - name: Change ImageMagick security policy on Ubuntu
       if: runner.os == 'Linux'
       run: |

--- a/lib/mindee/image_extraction.rb
+++ b/lib/mindee/image_extraction.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative 'image_extraction/common'
+require_relative 'image_extraction/multi_receipts_extractor'

--- a/lib/mindee/image_extraction/common.rb
+++ b/lib/mindee/image_extraction/common.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'common/image_extractor'

--- a/lib/mindee/image_extraction/common/extracted_image.rb
+++ b/lib/mindee/image_extraction/common/extracted_image.rb
@@ -16,6 +16,9 @@ module Mindee
       # Buffer object of the file's content.
       attr_reader :buffer
 
+      # Internal name for the file.
+      attr_reader :internal_file_name
+
       # Initializes the ExtractedImage with a buffer and an internal file name.
       #
       # @param input_source [LocalInputSource] Local source for input.
@@ -24,7 +27,12 @@ module Mindee
       def initialize(input_source, page_id, element_id)
         @buffer = StringIO.new(input_source.io_stream.read)
         @buffer.rewind
-        @internal_file_name = "#{input_source.filename}_p#{page_id}_#{element_id}.pdf"
+        extension = if input_source.pdf?
+                      'jpg'
+                    else
+                      File.extname(input_source.filename)
+                    end
+        @internal_file_name = "#{input_source.filename}_p#{page_id}_#{element_id}.#{extension}"
         @page_id = page_id
         @element_id = element_id.nil? ? 0 : element_id
       end
@@ -58,7 +66,7 @@ module Mindee
       # @return [FileInputSource] A BufferInput source.
       def as_source
         @buffer.rewind
-        FileInputSource.new(@buffer)
+        Mindee::Input::Source::BytesInputSource.new(@buffer.read, @internal_file_name)
       end
     end
   end

--- a/lib/mindee/image_extraction/common/extracted_image.rb
+++ b/lib/mindee/image_extraction/common/extracted_image.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative '../../input/sources'
+
+module Mindee
+  # Image Extraction Module.
+  module ImageExtraction
+    # Generic class for image extraction.
+    class ExtractedImage
+      # Id of the page the image was extracted from.
+      attr_reader :page_id
+
+      # Id of the element on a given page.
+      attr_reader :element_id
+
+      # Buffer object of the file's content.
+      attr_reader :buffer
+
+      # Initializes the ExtractedImage with a buffer and an internal file name.
+      #
+      # @param input_source [LocalInputSource] Local source for input.
+      # @param page_id [Integer] ID of the page the element was found on.
+      # @param element_id [Integer, nil] ID of the element in a page.
+      def initialize(input_source, page_id, element_id)
+        @buffer = StringIO.new(input_source.io_stream.read)
+        @buffer.rewind
+        @internal_file_name = "#{input_source.filename}_p#{page_id}_#{element_id}.pdf"
+        @page_id = page_id
+        @element_id = element_id.nil? ? 0 : element_id
+      end
+
+      # Saves the document to a file.
+      #
+      # @param output_path [String] Path to save the file to.
+      # @param file_format [String, nil] Optional MiniMagick-compatible format for the file. Inferred from file
+      # extension if not provided.
+      # @raise [MindeeError] If an invalid path or filename is provided.
+      def save_to_file(output_path, file_format = nil)
+        resolved_path = Pathname.new(output_path).realpath
+        if file_format.nil?
+          raise ArgumentError, 'Invalid file format.' if resolved_path.extname.delete('.').empty?
+
+          file_format = resolved_path.extname.delete('.').upcase
+        end
+        @buffer.rewind
+        image = MiniMagick::Image.read(@buffer)
+        image.format file_format.downcase
+        image.write resolved_path.to_s
+        logger.info("File saved successfully to '#{resolved_path}'.")
+      rescue TypeError
+        raise 'Invalid path/filename provided.'
+      rescue StandardError
+        raise "Could not save file #{Pathname.new(output_path).basename}."
+      end
+
+      # Return the file as a Mindee-compatible BufferInput source.
+      #
+      # @return [FileInputSource] A BufferInput source.
+      def as_source
+        @buffer.rewind
+        FileInputSource.new(@buffer)
+      end
+    end
+  end
+end

--- a/lib/mindee/image_extraction/common/image_extractor.rb
+++ b/lib/mindee/image_extraction/common/image_extractor.rb
@@ -13,84 +13,199 @@ module Mindee
     def attach_image_as_new_file(input_buffer)
       # Attaches an image as a new page in a PdfDocument object.
       #
-      # @param input_buffer [StringIO] Input buffer. Only supports JPEG.
+      # @param [StringIO] input_buffer Input buffer. Only supports JPEG.
       # @return [Origami::PDF] A PdfDocument handle.
 
       input_buffer.rewind
-      magick_image = MiniMagick::Image.open(input_buffer)
-      magick_image.format('pdf')
+      magick_image = MiniMagick::Image.read(input_buffer)
+      # NOTE: some jpeg images get rendered as three different versions of themselves per output if the format isn't
+      # converted.
+      magick_image.format('jpg')
+      original_density = magick_image.resolution
+      scale_factor = original_density[0].to_f / 4.166666 # No clue why bit the resolution needs to be reduced for
+      # the pdf otherwise the resulting image shrinks.
+      magick_image.format('pdf', 0, { density: scale_factor.to_s })
       io_buffer = StringIO.new
       magick_image.write(io_buffer)
       io_buffer.rewind
       Origami::PDF.read(io_buffer)
     end
 
+    # Extracts multiple images from a given local input source.
+    #
+    # @param [Mindee::Input::Source::LocalInputSource] input_source
+    # @param [Integer] page_id ID of the Page to extract from.
+    # @param [Array<Array<Mindee::Geometry::Point>>, Array<Mindee::Geometry::Quadrangle>] polygons List of coordinates
+    # to extract.
+    # @return [Array<Mindee::ImageExtraction::ExtractedImage>] Extracted Images.
     def extract_multiple_images_from_source(input_source, page_id, polygons)
-      # Extracts elements from a page based on a list of bounding boxes.
-      #
-      # @param input_source [LocalInputSource] Local Input source to extract elements from.
-      # @param page_id [Integer] ID of the page to extract from.
-      # @param polygons [Array<Array<Point>>] List of coordinates to pull the elements from.
-      # @return [Array<ExtractedImage>] List of byte arrays representing the extracted elements.
-      pdf_doc = load_pdf_doc(input_source)
+      new_stream = load_doc(input_source, page_id)
+      new_stream.seek(0)
+
+      extract_images_from_polygons(input_source, new_stream, page_id, polygons)
+    end
+
+    # Retrieves a PDF document's page.
+    #
+    # @param [Origami::PDF] pdf_doc Origami PDF handle.
+    # @param [Integer] page_id Page ID.
+    def get_page(pdf_doc, page_id)
       stream = StringIO.new
       pdf_doc.save(stream)
-      # NOTE: copying the page from the first PDF to the second does NOT work for this. Hence the call to the custom
-      # OrigaMindee pdf processor.
+
       options = {
         page_indexes: [page_id - 1],
         operation: :KEEP_ONLY,
         on_min_pages: 0,
       }
+
       stream.rewind
-      new_stream = Mindee::PDF::PdfProcessor.parse(stream, options)
+      Mindee::PDF::PdfProcessor.parse(stream, options)
+    end
 
+    # Extracts images from their positions on a file (as polygons).
+    #
+    # @param [Mindee::Input::Source::LocalInputSource] input_source Local input source.
+    # @param [StringIO] pdf_stream Buffer of the PDF.
+    # @param [Integer] page_id Page ID.
+    # @param [Array<Mindee::Geometry::Point>, Array<Mindee::Geometry::Polygon>, Array<Mindee::Geometry::Quadrangle>]
+    # polygons.
+    # @return [Array<Mindee::ImageExtraction::ExtractedImage>] Extracted Images.
+    def extract_images_from_polygons(input_source, pdf_stream, page_id, polygons)
       extracted_elements = []
-      polygons.each_with_index do |polygon, element_id|
-        new_stream.rewind
-        page_content = MiniMagick::Image.read(new_stream)
-        width = page_content[:width]
-        height = page_content[:height]
-        min_max_x = Geometry.get_min_max_x(
-          [polygon.top_left, polygon.bottom_right, polygon.top_right, polygon.bottom_left]
-        )
-        min_max_y = Geometry.get_min_max_y(
-          [polygon.top_left, polygon.bottom_right, polygon.top_right, polygon.bottom_left]
-        )
-        min_x = (min_max_x.min * width).to_i
-        min_y = (min_max_y.min * height).to_i
-        max_x = (min_max_x.max * width).to_i
-        max_y = (min_max_y.max * height).to_i
 
-        page_content.format('png')
-        page_content.crop("#{max_x - min_x}x#{max_y - min_y}+#{min_x}+#{min_y}")
+      polygons.each_with_index do |polygon, element_id|
+        polygon = normalize_polygon(polygon)
+        page_content = read_page_content(pdf_stream)
+
+        min_max_x = Geometry.get_min_max_x([
+                                             polygon.top_left,
+                                             polygon.bottom_right,
+                                             polygon.top_right,
+                                             polygon.bottom_left,
+                                           ])
+        min_max_y = Geometry.get_min_max_y([
+                                             polygon.top_left,
+                                             polygon.bottom_right,
+                                             polygon.top_right,
+                                             polygon.bottom_left,
+                                           ])
+        file_extension = determine_file_extension(input_source)
+        cropped_image = crop_image(page_content, min_max_x, min_max_y)
+        if file_extension == 'pdf'
+          cropped_image.format('jpg')
+        else
+          cropped_image.format(file_extension)
+        end
 
         buffer = StringIO.new
-        page_content.write(buffer)
-        buffer.rewind
+        write_image_to_buffer(cropped_image, buffer)
 
-        extracted_elements << ExtractedImage.new(
-          Mindee::Input::Source::BytesInputSource.new(buffer.read,
-                                                      "#{input_source.filename}_p#{page_id}_e#{element_id}.png"),
-          page_id,
-          element_id
-        )
+        file_name = generate_filename(input_source, page_id, element_id, file_extension)
+
+        extracted_elements << create_extracted_image(buffer, file_name, page_id, element_id)
       end
 
       extracted_elements
     end
 
-    def load_pdf_doc(input_file)
-      # Loads a PDF document from a local input source.
-      #
-      # @param input_file [LocalInputSource] Local input.
-      # @return [Origami::PDF] A valid PdfDocument handle.
-
-      if input_file.pdf?
-        input_file.io_stream.rewind
-        Origami::PDF.read(input_file.io_stream)
+    # Retrieves the bounding box of a polygon.
+    #
+    # @param [Array<Point>, Mindee::Geometry::Polygon] polygon
+    def normalize_polygon(polygon)
+      if polygon.is_a?(Mindee::Geometry::Polygon)
+        Mindee::Geometry.get_bounding_box(polygon)
       else
-        attach_image_as_new_file(input_file.io_stream)
+        polygon
+      end
+    end
+
+    # Loads a buffer into a MiniMagick Image.
+    #
+    # @param [StringIO] pdf_stream Buffer containg the PDF
+    # @return [MiniMagick::Image] a valid MiniMagick image handle.
+    def read_page_content(pdf_stream)
+      pdf_stream.rewind
+      MiniMagick::Image.read(pdf_stream)
+    end
+
+    # Crops a MiniMagick Image from a the given bounding box.
+    #
+    # @param [MiniMagick::Image] image Input Image.
+    # @param [Mindee::Geometry::MinMax] min_max_x minimum & maximum values for the x coordinates.
+    # @param [Mindee::Geometry::MinMax] min_max_y minimum & maximum values for the y coordinates.
+    def crop_image(image, min_max_x, min_max_y)
+      width = image[:width].to_i
+      height = image[:height].to_i
+
+      image.format('jpg')
+      new_width = (min_max_x.max - min_max_x.min) * width
+      new_height = (min_max_y.max - min_max_y.min) * height
+      image.crop("#{new_width}x#{new_height}+#{min_max_x.min * width}+#{min_max_y.min * height}")
+
+      image
+    end
+
+    # Writes a MiniMagick::Image to a buffer.
+    #
+    # @param [MiniMagick::Image] image a valid MiniMagick image.
+    # @param [Object] buffer
+    def write_image_to_buffer(image, buffer)
+      image.write(buffer)
+      buffer.rewind
+    end
+
+    # Retrieves the file extension from the main file to apply it to the extracted images. Note: coerces pdf as jpg.
+    #
+    # @param [Mindee::Input::Source::LocalInputSource] input_source Local input source.
+    # @return [String] A valid file extension.
+    def determine_file_extension(input_source)
+      if input_source.pdf? || input_source.filename.downcase.end_with?('pdf')
+        'jpg'
+      else
+        File.extname(input_source.filename).strip.downcase[1..]
+      end
+    end
+
+    # Generates a filename from the main input source.
+    #
+    # @param [Mindee::Input::Source::LocalInputSource] input_source Local input source.
+    # @param [Integer] page_id ID of the page the element was extracted from.
+    # @param [Integer] element_id ID of the element on a given page
+    # @param [String] file_extension extension as extracted from the main file.
+    # @return [String] The generated filename.
+    def generate_filename(input_source, page_id, element_id, file_extension)
+      "#{input_source.filename}_page#{page_id}-#{element_id}.#{file_extension}"
+    end
+
+    # Generates an ExtractedImage.
+    #
+    # @param [StringIO] buffer Buffer containing the image.
+    # @param [String] file_name Name for the file.
+    # @param [Object] page_id ID of the page the file was generated from.
+    # @param [Object] element_id ID of the element of a given page.
+    def create_extracted_image(buffer, file_name, page_id, element_id)
+      buffer.rewind
+      ExtractedImage.new(
+        Mindee::Input::Source::BytesInputSource.new(buffer.read, file_name),
+        page_id,
+        element_id
+      )
+    end
+
+    # Loads a single_page from an image file or a pdf document.
+    #
+    # @param input_file [LocalInputSource] Local input.
+    # @param [Integer] page_id Page ID.
+    # @return [MiniMagick::Image] A valid PdfDocument handle.
+    def load_doc(input_file, page_id)
+      input_file.io_stream.rewind
+      if input_file.pdf?
+        new_stream = get_page(Origami::PDF.read(input_file.io_stream), page_id)
+        new_stream.rewind
+        new_stream
+      else
+        input_file.io_stream
       end
     end
   end

--- a/lib/mindee/image_extraction/common/image_extractor.rb
+++ b/lib/mindee/image_extraction/common/image_extractor.rb
@@ -63,8 +63,7 @@ module Mindee
     # @param [Mindee::Input::Source::LocalInputSource] input_source Local input source.
     # @param [StringIO] pdf_stream Buffer of the PDF.
     # @param [Integer] page_id Page ID.
-    # @param [Array<Mindee::Geometry::Point>, Array<Mindee::Geometry::Polygon>, Array<Mindee::Geometry::Quadrangle>]
-    # polygons.
+    # @param [Array<Mindee::Geometry::Point, Mindee::Geometry::Polygon, Mindee::Geometry::Quadrangle>] polygons
     # @return [Array<Mindee::ImageExtraction::ExtractedImage>] Extracted Images.
     def extract_images_from_polygons(input_source, pdf_stream, page_id, polygons)
       extracted_elements = []

--- a/lib/mindee/image_extraction/common/image_extractor.rb
+++ b/lib/mindee/image_extraction/common/image_extractor.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'mini_magick'
+require 'origami'
+require 'stringio'
+require 'tempfile'
+require_relative '../../input/sources'
+require_relative 'extracted_image'
+
+module Mindee
+  # Image Extraction Module.
+  module ImageExtraction
+    def attach_image_as_new_file(input_buffer)
+      # Attaches an image as a new page in a PdfDocument object.
+      #
+      # @param input_buffer [StringIO] Input buffer. Only supports JPEG.
+      # @return [Origami::PDF] A PdfDocument handle.
+
+      input_buffer.rewind
+      magick_image = MiniMagick::Image.open(input_buffer)
+      magick_image.format('pdf')
+      io_buffer = StringIO.new
+      magick_image.write(io_buffer)
+      io_buffer.rewind
+      Origami::PDF.read(io_buffer)
+    end
+
+    def extract_multiple_images_from_source(input_source, page_id, polygons)
+      # Extracts elements from a page based on a list of bounding boxes.
+      #
+      # @param input_source [LocalInputSource] Local Input source to extract elements from.
+      # @param page_id [Integer] ID of the page to extract from.
+      # @param polygons [Array<Array<Point>>] List of coordinates to pull the elements from.
+      # @return [Array<ExtractedImage>] List of byte arrays representing the extracted elements.
+      pdf_doc = load_pdf_doc(input_source)
+      stream = StringIO.new
+      pdf_doc.save(stream)
+      # NOTE: copying the page from the first PDF to the second does NOT work for this. Hence the call to the custom
+      # OrigaMindee pdf processor.
+      options = {
+        page_indexes: [page_id - 1],
+        operation: :KEEP_ONLY,
+        on_min_pages: 0,
+      }
+      stream.rewind
+      new_stream = Mindee::PDF::PdfProcessor.parse(stream, options)
+
+      extracted_elements = []
+      polygons.each_with_index do |polygon, element_id|
+        new_stream.rewind
+        page_content = MiniMagick::Image.read(new_stream)
+        width = page_content[:width]
+        height = page_content[:height]
+        min_max_x = Geometry.get_min_max_x(
+          [polygon.top_left, polygon.bottom_right, polygon.top_right, polygon.bottom_left]
+        )
+        min_max_y = Geometry.get_min_max_y(
+          [polygon.top_left, polygon.bottom_right, polygon.top_right, polygon.bottom_left]
+        )
+        min_x = (min_max_x.min * width).to_i
+        min_y = (min_max_y.min * height).to_i
+        max_x = (min_max_x.max * width).to_i
+        max_y = (min_max_y.max * height).to_i
+
+        page_content.format('png')
+        page_content.crop("#{max_x - min_x}x#{max_y - min_y}+#{min_x}+#{min_y}")
+
+        buffer = StringIO.new
+        page_content.write(buffer)
+        buffer.rewind
+
+        extracted_elements << ExtractedImage.new(
+          Mindee::Input::Source::BytesInputSource.new(buffer.read,
+                                                      "#{input_source.filename}_p#{page_id}_e#{element_id}.png"),
+          page_id,
+          element_id
+        )
+      end
+
+      extracted_elements
+    end
+
+    def load_pdf_doc(input_file)
+      # Loads a PDF document from a local input source.
+      #
+      # @param input_file [LocalInputSource] Local input.
+      # @return [Origami::PDF] A valid PdfDocument handle.
+
+      if input_file.pdf?
+        input_file.io_stream.rewind
+        Origami::PDF.read(input_file.io_stream)
+      else
+        attach_image_as_new_file(input_file.io_stream)
+      end
+    end
+  end
+end

--- a/lib/mindee/image_extraction/multi_receipts_extractor.rb
+++ b/lib/mindee/image_extraction/multi_receipts_extractor.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'multi_receipts_extractor/multi_receipts_extractor'

--- a/lib/mindee/image_extraction/multi_receipts_extractor/multi_receipts_extractor.rb
+++ b/lib/mindee/image_extraction/multi_receipts_extractor/multi_receipts_extractor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mindee
+  # Image Extraction Module.
+  module ImageExtraction
+    def extract_receipts(input_source, inference)
+      # Extracts individual receipts from multi-receipts documents.
+      #
+      # @param input_source [LocalInputSource] Local Input Source to extract sub-receipts from.
+      # @param inference [Inference] Results of the inference.
+      # @return [Array<ExtractedImage>] Individual extracted receipts as an array of ExtractedMultiReceiptsImage.
+
+      images = []
+      raise 'No possible receipts candidates found for MultiReceipts extraction.' unless inference.prediction.receipts
+
+      (0...input_source.count_pdf_pages).each do |page_id|
+        receipt_positions = inference.pages[page_id].prediction.receipts.map(&:bounding_box)
+        images.concat(
+          extract_multiple_images_from_source(input_source, page_id + 1, receipt_positions)
+        )
+      end
+
+      images
+    end
+  end
+end

--- a/lib/mindee/input/sources.rb
+++ b/lib/mindee/input/sources.rb
@@ -118,6 +118,14 @@ module Mindee
           @io_stream.close if close
           ['document', data, { filename: Mindee::Input::Source.convert_to_unicode_escape(@filename) }]
         end
+
+        def count_pdf_pages
+          return 1 unless pdf?
+
+          @io_stream.seek(0)
+          pdf_processor = Mindee::PDF::PdfProcessor.open_pdf(@io_stream)
+          pdf_processor.pages.size
+        end
       end
 
       # Load a document from a path.

--- a/mindee.gemspec
+++ b/mindee.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6')
 
   spec.add_runtime_dependency 'marcel', '~> 1.0.2'
+  spec.add_runtime_dependency 'mini_magick', '~> 4.13.0'
   spec.add_runtime_dependency 'origamindee', '~> 3.1.0'
 
   spec.add_development_dependency 'rake', '~> 12.3.3'

--- a/spec/extraction/tax_extractor_spec.rb
+++ b/spec/extraction/tax_extractor_spec.rb
@@ -6,8 +6,6 @@ require 'mindee/parsing'
 
 require_relative '../data'
 
-DIR_OCR = File.join(DATA_DIR, 'products', 'extras', 'ocr').freeze
-
 describe Mindee::Product::Cropper::CropperV1 do
   context 'A custom tax extraction' do
     it 'should properly extract the tax from a document.' do

--- a/spec/image_extraction/image_extractor_spec.rb
+++ b/spec/image_extraction/image_extractor_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'mindee/product'
+require 'mindee/input/sources'
+require 'mindee/image_extraction'
+require_relative '../data'
+
+describe Mindee::ImageExtraction do
+  include Mindee::ImageExtraction
+  let(:multi_receipts_single_page_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'default_sample.jpg')
+  end
+
+  let(:multi_receipts_single_page_json_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'response_v1')
+  end
+
+  let(:multi_receipts_multi_page_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'multipage_sample.pdf')
+  end
+
+  let(:multi_receipts_multi_page_json_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'response_v1')
+  end
+
+  describe '#extract_receipts' do
+    context 'with single page multi receipt' do
+      it 'splits receipts correctly' do
+        input_sample = Mindee::Input::Source::PathInputSource.new(multi_receipts_single_page_path)
+        response = load_json(multi_receipts_single_page_json_path, 'complete.json')
+        doc = Mindee::Product::MultiReceiptsDetector::MultiReceiptsDetectorV1.new(response['document']['inference'])
+        extracted_receipts = extract_receipts(input_sample, doc)
+
+        expect(extracted_receipts.size).to eq(6)
+
+        expect(extracted_receipts[0].page_id).to eq(1)
+        expect(extracted_receipts[0].element_id).to eq(0)
+        image_buffer0 = MiniMagick::Image.read(extracted_receipts[0].buffer)
+        expect(image_buffer0.dimensions).to eq([341, 505])
+
+        expect(extracted_receipts[1].page_id).to eq(1)
+        expect(extracted_receipts[1].element_id).to eq(1)
+        image_buffer1 = MiniMagick::Image.read(extracted_receipts[1].buffer)
+        expect(image_buffer1.dimensions).to eq([461, 908])
+
+        expect(extracted_receipts[2].page_id).to eq(1)
+        expect(extracted_receipts[2].element_id).to eq(2)
+        image_buffer2 = MiniMagick::Image.read(extracted_receipts[2].buffer)
+        expect(image_buffer2.dimensions).to eq([471, 790])
+
+        expect(extracted_receipts[3].page_id).to eq(1)
+        expect(extracted_receipts[3].element_id).to eq(3)
+        image_buffer3 = MiniMagick::Image.read(extracted_receipts[3].buffer)
+        expect(image_buffer3.dimensions).to eq([464, 1200])
+
+        expect(extracted_receipts[4].page_id).to eq(1)
+        expect(extracted_receipts[4].element_id).to eq(4)
+        image_buffer4 = MiniMagick::Image.read(extracted_receipts[4].buffer)
+        expect(image_buffer4.dimensions).to eq([530, 943])
+
+        expect(extracted_receipts[5].page_id).to eq(1)
+        expect(extracted_receipts[5].element_id).to eq(5)
+        image_buffer5 = MiniMagick::Image.read(extracted_receipts[5].buffer)
+        expect(image_buffer5.dimensions).to eq([367, 593])
+      end
+    end
+
+    context 'with multi page receipt' do
+      it 'splits receipts correctly' do
+        input_sample = Mindee::Input::Source::PathInputSource.new(multi_receipts_multi_page_path)
+        response = load_json(multi_receipts_multi_page_json_path, 'multipage_sample.json')
+        doc = Mindee::Product::MultiReceiptsDetector::MultiReceiptsDetectorV1.new(response['document']['inference'])
+        extracted_receipts = extract_receipts(input_sample, doc)
+
+        expect(extracted_receipts.size).to eq(5)
+
+        expect(extracted_receipts[0].page_id).to eq(1)
+        expect(extracted_receipts[0].element_id).to eq(0)
+        image_buffer0 = MiniMagick::Image.read(extracted_receipts[0].buffer)
+        expect(image_buffer0.dimensions).to eq([198, 566])
+
+        expect(extracted_receipts[1].page_id).to eq(1)
+        expect(extracted_receipts[1].element_id).to eq(1)
+        image_buffer1 = MiniMagick::Image.read(extracted_receipts[1].buffer)
+        expect(image_buffer1.dimensions).to eq([206, 382])
+
+        expect(extracted_receipts[2].page_id).to eq(1)
+        expect(extracted_receipts[2].element_id).to eq(2)
+        image_buffer2 = MiniMagick::Image.read(extracted_receipts[2].buffer)
+        expect(image_buffer2.dimensions).to eq([195, 231])
+
+        expect(extracted_receipts[3].page_id).to eq(2)
+        expect(extracted_receipts[3].element_id).to eq(0)
+        image_buffer3 = MiniMagick::Image.read(extracted_receipts[3].buffer)
+        expect(image_buffer3.dimensions).to eq([213, 356])
+
+        expect(extracted_receipts[4].page_id).to eq(2)
+        expect(extracted_receipts[4].element_id).to eq(1)
+        image_buffer4 = MiniMagick::Image.read(extracted_receipts[4].buffer)
+        expect(image_buffer4.dimensions).to eq([212, 516])
+      end
+    end
+  end
+end

--- a/spec/image_extraction/image_extractor_spec.rb
+++ b/spec/image_extraction/image_extractor_spec.rb
@@ -17,13 +17,8 @@ describe Mindee::ImageExtraction do
 
   context 'an image extractor' do
     it 'extracts barcode images correctly' do
-      # Assuming barcode_path and barcode_json_path are fixtures provided by RSpec
-
-      # Load JSON fixture
       json_data = JSON.parse(File.read(barcode_json_path))
       inference = Mindee::Product::BarcodeReader::BarcodeReaderV1.new(json_data['document']['inference'])
-
-      # Extract polygon coordinates
       barcodes1 = []
       inference.prediction.codes_1d.each do |barcode|
         barcodes1.push(barcode.polygon)
@@ -32,16 +27,11 @@ describe Mindee::ImageExtraction do
       inference.prediction.codes_2d.each do |barcode|
         barcodes2.push(barcode.polygon)
       end
-
-      # Create input source
       input_source = Mindee::Input::Source::PathInputSource.new(barcode_path)
-
-      # Extract images
 
       extracted_barcodes_1d = extract_multiple_images_from_source(input_source, 1, barcodes1)
       extracted_barcodes_2d = extract_multiple_images_from_source(input_source, 1, barcodes2)
 
-      # Assertions
       expect(extracted_barcodes_1d.size).to eq(1)
       expect(extracted_barcodes_2d.size).to eq(2)
 

--- a/spec/image_extraction/multi_receipts_extractor_spec.rb
+++ b/spec/image_extraction/multi_receipts_extractor_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'mindee/product'
+require 'mindee/input/sources'
+require 'mindee/image_extraction'
+require_relative '../data'
+
+describe Mindee::ImageExtraction do
+  include Mindee::ImageExtraction
+  let(:multi_receipts_single_page_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'default_sample.jpg')
+  end
+
+  let(:multi_receipts_single_page_json_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'response_v1')
+  end
+
+  let(:multi_receipts_multi_page_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'multipage_sample.pdf')
+  end
+
+  let(:multi_receipts_multi_page_json_path) do
+    File.join(DATA_DIR, 'products', 'multi_receipts_detector', 'response_v1')
+  end
+
+  context 'with single page multi receipt' do
+    it 'splits receipts correctly' do
+      input_sample = Mindee::Input::Source::PathInputSource.new(multi_receipts_single_page_path)
+      response = load_json(multi_receipts_single_page_json_path, 'complete.json')
+      doc = Mindee::Product::MultiReceiptsDetector::MultiReceiptsDetectorV1.new(response['document']['inference'])
+      extracted_receipts = extract_receipts(input_sample, doc)
+
+      expect(extracted_receipts.size).to eq(6)
+
+      expect(extracted_receipts[0].page_id).to eq(1)
+      expect(extracted_receipts[0].element_id).to eq(0)
+      image_buffer0 = MiniMagick::Image.read(extracted_receipts[0].buffer)
+      # NOTE: this varies from other SDKs due to different image processing.
+      expect(image_buffer0.dimensions).to eq([341, 504])
+      expect(extracted_receipts[0].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[1].page_id).to eq(1)
+      expect(extracted_receipts[1].element_id).to eq(1)
+      image_buffer1 = MiniMagick::Image.read(extracted_receipts[1].buffer)
+      expect(image_buffer1.dimensions).to eq([461, 908])
+      expect(extracted_receipts[1].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[2].page_id).to eq(1)
+      expect(extracted_receipts[2].element_id).to eq(2)
+      image_buffer2 = MiniMagick::Image.read(extracted_receipts[2].buffer)
+      expect(image_buffer2.dimensions).to eq([472, 790])
+      expect(extracted_receipts[2].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[3].page_id).to eq(1)
+      expect(extracted_receipts[3].element_id).to eq(3)
+      image_buffer3 = MiniMagick::Image.read(extracted_receipts[3].buffer)
+      expect(image_buffer3.dimensions).to eq([464, 1200])
+      expect(extracted_receipts[3].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[4].page_id).to eq(1)
+      expect(extracted_receipts[4].element_id).to eq(4)
+      image_buffer4 = MiniMagick::Image.read(extracted_receipts[4].buffer)
+      expect(image_buffer4.dimensions).to eq([530, 944])
+      expect(extracted_receipts[4].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[5].page_id).to eq(1)
+      expect(extracted_receipts[5].element_id).to eq(5)
+      image_buffer5 = MiniMagick::Image.read(extracted_receipts[5].buffer)
+      expect(image_buffer5.dimensions).to eq([366, 593])
+      expect(extracted_receipts[5].as_source.filename).to end_with('jpg')
+    end
+  end
+
+  context 'with multi page receipt' do
+    it 'splits receipts correctly' do
+      input_sample = Mindee::Input::Source::PathInputSource.new(multi_receipts_multi_page_path)
+      response = load_json(multi_receipts_multi_page_json_path, 'multipage_sample.json')
+      doc = Mindee::Product::MultiReceiptsDetector::MultiReceiptsDetectorV1.new(response['document']['inference'])
+      extracted_receipts = extract_receipts(input_sample, doc)
+
+      expect(extracted_receipts.size).to eq(5)
+
+      expect(extracted_receipts[0].page_id).to eq(1)
+      expect(extracted_receipts[0].element_id).to eq(0)
+      image_buffer0 = MiniMagick::Image.read(extracted_receipts[0].buffer)
+      expect(image_buffer0.dimensions).to eq([198, 566])
+      expect(extracted_receipts[0].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[1].page_id).to eq(1)
+      expect(extracted_receipts[1].element_id).to eq(1)
+      image_buffer1 = MiniMagick::Image.read(extracted_receipts[1].buffer)
+      expect(image_buffer1.dimensions).to eq([205, 382])
+      expect(extracted_receipts[1].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[2].page_id).to eq(1)
+      expect(extracted_receipts[2].element_id).to eq(2)
+      image_buffer2 = MiniMagick::Image.read(extracted_receipts[2].buffer)
+      expect(image_buffer2.dimensions).to eq([195, 232])
+      expect(extracted_receipts[2].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[3].page_id).to eq(2)
+      expect(extracted_receipts[3].element_id).to eq(0)
+      image_buffer3 = MiniMagick::Image.read(extracted_receipts[3].buffer)
+      expect(image_buffer3.dimensions).to eq([213, 355])
+      expect(extracted_receipts[3].as_source.filename).to end_with('jpg')
+
+      expect(extracted_receipts[4].page_id).to eq(2)
+      expect(extracted_receipts[4].element_id).to eq(1)
+      image_buffer4 = MiniMagick::Image.read(extracted_receipts[4].buffer)
+      expect(image_buffer4.dimensions).to eq([212, 516])
+      expect(extracted_receipts[4].as_source.filename).to end_with('jpg')
+    end
+  end
+end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :sparkles: add support for multi-receipts auto-extraction
* :recycle: add support for image extraction namespace
* :recycle: add mini_magick dependency

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
