### PR TITLE
:recycle: temporarily remove support for ruby 3.4 until origamindee is fixed

### DIFF
--- a/.github/workflows/_test-code-samples.yml
+++ b/.github/workflows/_test-code-samples.yml
@@ -15,7 +15,6 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
-          - "3.4"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test-integrations.yml
+++ b/.github/workflows/_test-integrations.yml
@@ -22,7 +22,6 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
-          - "3.4"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/_test-units.yml
+++ b/.github/workflows/_test-units.yml
@@ -22,7 +22,6 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
-          - "3.4"
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
