### PR TITLE
:recycle: patch-pin rubocop version to prevent unexpected CI failures

### DIFF
--- a/mindee.gemspec
+++ b/mindee.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rbs', '~> 3.6'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  spec.add_development_dependency 'rubocop', '~> 1.76'
+  spec.add_development_dependency 'rubocop', '~> 1.76.0'
   spec.add_development_dependency 'steep', '~> 1.7'
   spec.add_development_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Use stricter pinning on the rubocop dependency version as they frequently add new cops to minor versions, which sometimes cause discrepencies between local & CI, or worse: PR CI & main branch CI.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
